### PR TITLE
feat: Introduce ryot_brain crate for advanced NPC behaviors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5202,6 +5202,7 @@ dependencies = [
  "bevy_ecs",
  "bevy_math",
  "bevy_tasks",
+ "bevy_utils",
  "derive_more",
  "pathfinding",
  "quickcheck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1397,6 +1397,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "big-brain"
+version = "0.19.0"
+source = "git+https://github.com/zkat/big-brain.git?branch=main#98337faacd5eb720cc820628fd1bfa07e6c8effa"
+dependencies = [
+ "bevy",
+ "big-brain-derive",
+]
+
+[[package]]
+name = "big-brain-derive"
+version = "0.19.0"
+source = "git+https://github.com/zkat/big-brain.git?branch=main#98337faacd5eb720cc820628fd1bfa07e6c8effa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5065,6 +5084,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryot_brain"
+version = "0.2.2"
+dependencies = [
+ "bevy",
+ "big-brain",
+ "derive_more",
+ "rand",
+ "ryot_core",
+ "ryot_pathfinder",
+ "ryot_tiled",
+ "ryot_utils",
+]
+
+[[package]]
 name = "ryot_compass"
 version = "0.1.0"
 dependencies = [
@@ -5150,6 +5183,7 @@ name = "ryot_internal"
 version = "0.2.2"
 dependencies = [
  "ryot_assets",
+ "ryot_brain",
  "ryot_core",
  "ryot_pathfinder",
  "ryot_ray_casting",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ bevy_window = "0.13"
 # Ryot dependencies
 ryot = { path = "./crates/ryot", version = "0.2" }
 ryot_assets = { path = "./crates/ryot_assets", version = "0.2" }
+ryot_brain = { path = "./crates/ryot_brain", version = "0.2" }
 ryot_core = { path = "./crates/ryot_core", version = "0.2" }
 ryot_derive = { path = "./crates/ryot_derive", version = "0.2" }
 ryot_internal = { path = "./crates/ryot_internal", version = "0.2" }

--- a/crates/ryot/Cargo.toml
+++ b/crates/ryot/Cargo.toml
@@ -33,6 +33,7 @@ default = [
 ]
 
 bevy = ["ryot_internal/bevy"]
+brain = ["ryot_internal/brain"]
 
 tibia = ["ryot_internal/ryot_tibia"]
 

--- a/crates/ryot/src/plugins/game.rs
+++ b/crates/ryot/src/plugins/game.rs
@@ -37,8 +37,15 @@ impl NavigableApp for App {
     fn add_navigable<N: Navigable + Copy + Default + Component>(&mut self) -> &mut Self {
         self.init_resource_once::<Cache<TilePosition, N>>()
             .add_systems(
+                PreUpdate,
+                collect_updatable_positions::<TilePosition>
+                    .pipe(build_new_flags_for_map::<N>)
+                    .pipe(update_tile_flag_cache::<N>)
+                    .in_set(CacheSystems::UpdateCache),
+            )
+            .add_systems(
                 PostUpdate,
-                collect_updatable_positions
+                collect_updatable_positions::<PreviousPosition>
                     .pipe(build_new_flags_for_map::<N>)
                     .pipe(update_tile_flag_cache::<N>)
                     .in_set(CacheSystems::UpdateCache),

--- a/crates/ryot/src/plugins/mod.rs
+++ b/crates/ryot/src/plugins/mod.rs
@@ -16,7 +16,7 @@ pub mod prelude {
         content_plugin,
         plugins::{
             content::{BaseContentPlugin, MetaContentPlugin, VisualContentPlugin},
-            game::{ElevationPlugin, GamePlugin, NavigablePlugin},
+            game::{ElevationPlugin, GamePlugin, NavigableApp},
             sprites::{RyotDrawingPlugin, RyotSpritePlugin},
         },
     };

--- a/crates/ryot_brain/Cargo.toml
+++ b/crates/ryot_brain/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "ryot_brain"
+version = "0.2.2"
+edition = "2021"
+authors = [
+    "Lucas Grossi <lucas.ggrosis@gmail.com>",
+    "Luan Santos <cargo@luan.sh>",
+]
+license = "AGPL-3.0-only"
+description = "Part of the Ryot game engine ecosystem, offering advanced NPC behaviors using big_brain and bevy."
+homepage = "https://github.com/ry-ot/Ryot"
+repository = "https://github.com/ry-ot/Ryot"
+documentation = "https://docs.rs/ryot/"
+keywords = ["bevy", "ai", "ryot"]
+categories = ["game-development", "game-engines", "games"]
+
+[package.metadata.docs.rs]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
+all-features = true
+
+[dependencies]
+bevy.workspace = true
+big-brain = { git = "https://github.com/zkat/big-brain.git", branch = "main" }
+
+ryot_core.workspace = true
+ryot_tiled.workspace = true
+ryot_pathfinder.workspace = true
+ryot_utils.workspace = true
+
+derive_more.workspace = true
+rand = "0.8.5"

--- a/crates/ryot_brain/Cargo.toml
+++ b/crates/ryot_brain/Cargo.toml
@@ -23,9 +23,12 @@ bevy.workspace = true
 big-brain = { git = "https://github.com/zkat/big-brain.git", branch = "main" }
 
 ryot_core.workspace = true
-ryot_tiled.workspace = true
+ryot_tiled = { workspace = true, features = ["bevy", "pathfinding"] }
 ryot_pathfinder.workspace = true
 ryot_utils.workspace = true
 
 derive_more.workspace = true
 rand = "0.8.5"
+
+[[example]]
+name = "pathfinding"

--- a/crates/ryot_brain/examples/pathfinding.rs
+++ b/crates/ryot_brain/examples/pathfinding.rs
@@ -1,0 +1,107 @@
+use bevy::app::App;
+use bevy::diagnostic::*;
+use bevy::log::LogPlugin;
+use bevy::prelude::*;
+use bevy::MinimalPlugins;
+use big_brain::pickers::FirstToScore;
+use big_brain::prelude::Thinker;
+use big_brain::{BigBrainPlugin, BigBrainSet};
+use ryot_brain::prelude::{
+    find_closest_target, find_path_scorer, follow_path, follow_path_scorer, moves_randomly,
+    MovesRandomly, PathFindingThinker, PathFollowingThinker,
+};
+use ryot_core::game::Point;
+use ryot_core::prelude::Flags;
+use ryot_pathfinder::pathable::PathableApp;
+use ryot_tiled::prelude::{OrdinalDirection, TilePosition};
+use ryot_utils::prelude::*;
+
+#[derive(Component, Copy, Debug, Clone)]
+pub struct Target;
+
+fn main() {
+    let mut app = App::new();
+
+    app.add_plugins(MinimalPlugins)
+        .add_plugins(LogPlugin {
+            // Use `RUST_LOG=big_brain=trace,sequence=trace cargo run --example sequence --features=trace` to see extra tracing output.
+            filter: "ryot_brain=debug".to_string(),
+            ..default()
+        })
+        .add_pathable::<TilePosition, Flags>()
+        .add_systems(Startup, (spawn_basic))
+        .add_plugins(BigBrainPlugin::new(PreUpdate))
+        .add_systems(
+            PreUpdate,
+            (find_path_scorer::<Target>, follow_path_scorer).in_set(BigBrainSet::Scorers),
+        )
+        .add_systems(
+            PreUpdate,
+            (
+                find_closest_target::<Target>,
+                follow_path.pipe(initiate_walk),
+                moves_randomly.pipe(initiate_walk),
+            )
+                .in_set(BigBrainSet::Actions)
+                .after(CacheSystems::UpdateCache),
+        )
+        .add_systems(Update, shuffle_target_positions_every_x_seconds)
+        .add_plugins((
+            FrameTimeDiagnosticsPlugin,
+            EntityCountDiagnosticsPlugin,
+            SystemInformationDiagnosticsPlugin,
+            LogDiagnosticsPlugin::default(),
+        ))
+        .run();
+}
+
+fn initiate_walk(
+    In(walks): In<Vec<(Entity, OrdinalDirection)>>,
+    mut positions: Query<&mut TilePosition>,
+) {
+    for (entity, direction) in walks {
+        if let Ok(mut position) = positions.get_mut(entity) {
+            *position = TilePosition(position.0 + IVec2::from(direction).extend(0))
+        }
+    }
+}
+
+fn spawn_basic(mut commands: Commands) {
+    commands.spawn((
+        TilePosition::generate(
+            rand::random::<i32>() % 100 + 1,
+            rand::random::<i32>() % 100 + 1,
+            0,
+        ),
+        Target,
+    ));
+    for i in 0..=400_000 {
+        commands.spawn((
+            TilePosition::generate(
+                rand::random::<i32>() % 100 + 1,
+                rand::random::<i32>() % 100 + 1,
+                0,
+            ),
+            Thinker::build()
+                .label("ChaserThinker")
+                .picker(FirstToScore::new(0.6))
+                .find_path::<Target>()
+                .follows_path_with_fallback(MovesRandomly),
+        ));
+    }
+}
+
+fn shuffle_target_positions_every_x_seconds(
+    time: Res<Time>,
+    mut query: Query<&mut TilePosition, With<Target>>,
+) {
+    for mut position in &mut query.iter_mut() {
+        if time.elapsed_seconds() % 5. < 0.0001 {
+            *position = TilePosition::generate(
+                rand::random::<i32>() % 100 + 1,
+                rand::random::<i32>() % 100 + 1,
+                0,
+            );
+        }
+    }
+}

--- a/crates/ryot_brain/examples/pathfinding.rs
+++ b/crates/ryot_brain/examples/pathfinding.rs
@@ -8,7 +8,7 @@ use big_brain::prelude::Thinker;
 use big_brain::{BigBrainPlugin, BigBrainSet};
 use ryot_brain::prelude::{
     find_closest_target, find_path_scorer, follow_path, follow_path_scorer, moves_randomly,
-    MovesRandomly, PathFindingThinker, PathFollowingThinker,
+    MovesRandomly, PathFindingThinker, PathFollowingThinker, ThinkerBundle, WalkTo,
 };
 use ryot_core::game::Point;
 use ryot_core::prelude::Flags;
@@ -28,6 +28,8 @@ fn main() {
             filter: "ryot_brain=debug".to_string(),
             ..default()
         })
+        .add_event::<WalkTo>()
+        .add_cooldown::<Thinker>()
         .add_pathable::<TilePosition, Flags>()
         .add_systems(Startup, spawn_basic)
         .add_plugins(BigBrainPlugin::new(PreUpdate))
@@ -37,15 +39,17 @@ fn main() {
         )
         .add_systems(
             PreUpdate,
-            (
-                find_closest_target::<Target>,
-                follow_path.pipe(initiate_walk),
-                moves_randomly.pipe(initiate_walk),
-            )
+            (find_closest_target::<Target>, follow_path, moves_randomly)
                 .in_set(BigBrainSet::Actions)
                 .after(CacheSystems::UpdateCache),
         )
-        .add_systems(Update, shuffle_target_positions_every_x_seconds)
+        .add_systems(
+            Update,
+            (
+                walk_to.pipe(initiate_walk),
+                shuffle_target_positions_every_x_seconds,
+            ),
+        )
         .add_plugins((
             FrameTimeDiagnosticsPlugin,
             EntityCountDiagnosticsPlugin,
@@ -53,6 +57,21 @@ fn main() {
             LogDiagnosticsPlugin::default(),
         ))
         .run();
+}
+
+fn walk_to(
+    mut walk_reader: EventReader<WalkTo>,
+    mut positions: Query<&mut TilePosition>,
+) -> Vec<(Entity, OrdinalDirection)> {
+    walk_reader
+        .read()
+        .filter_map(|WalkTo(entity, next_pos)| {
+            Some((
+                *entity,
+                positions.get_mut(*entity).ok()?.direction_to(*next_pos),
+            ))
+        })
+        .collect::<Vec<_>>()
 }
 
 fn initiate_walk(
@@ -75,18 +94,22 @@ fn spawn_basic(mut commands: Commands) {
         ),
         Target,
     ));
-    for _ in 0..=400_000 {
+    for _ in 0..=1 {
         commands.spawn((
             TilePosition::generate(
                 rand::random::<i32>() % 100 + 1,
                 rand::random::<i32>() % 100 + 1,
                 0,
             ),
-            Thinker::build()
-                .label("ChaserThinker")
-                .picker(FirstToScore::new(0.6))
-                .find_path::<Target>()
-                .follows_path_with_fallback(1., MovesRandomly),
+            ThinkerBundle::new(
+                Thinker::build()
+                    .label("ChaserThinker")
+                    .picker(FirstToScore::new(0.6))
+                    .find_path::<Target>()
+                    .follows_path()
+                    .otherwise(MovesRandomly),
+                Cooldown::from_seconds(0.5),
+            ),
         ));
     }
 }

--- a/crates/ryot_brain/examples/pathfinding.rs
+++ b/crates/ryot_brain/examples/pathfinding.rs
@@ -29,7 +29,7 @@ fn main() {
             ..default()
         })
         .add_pathable::<TilePosition, Flags>()
-        .add_systems(Startup, (spawn_basic))
+        .add_systems(Startup, spawn_basic)
         .add_plugins(BigBrainPlugin::new(PreUpdate))
         .add_systems(
             PreUpdate,
@@ -75,7 +75,7 @@ fn spawn_basic(mut commands: Commands) {
         ),
         Target,
     ));
-    for i in 0..=400_000 {
+    for _ in 0..=400_000 {
         commands.spawn((
             TilePosition::generate(
                 rand::random::<i32>() % 100 + 1,
@@ -86,7 +86,7 @@ fn spawn_basic(mut commands: Commands) {
                 .label("ChaserThinker")
                 .picker(FirstToScore::new(0.6))
                 .find_path::<Target>()
-                .follows_path_with_fallback(MovesRandomly),
+                .follows_path_with_fallback(1., MovesRandomly),
         ));
     }
 }

--- a/crates/ryot_brain/src/find_closest.rs
+++ b/crates/ryot_brain/src/find_closest.rs
@@ -1,0 +1,163 @@
+use bevy::prelude::*;
+use big_brain::actions::ActionState;
+use big_brain::prelude::*;
+use derive_more::{Deref, DerefMut};
+use ryot_core::prelude::*;
+use ryot_pathfinder::prelude::*;
+use ryot_tiled::prelude::*;
+use ryot_utils::prelude::*;
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::time::Duration;
+
+pub trait Thinking = Clone + Debug + ThreadSafe;
+
+#[derive(Clone, Copy, Component, Debug, Deref, DerefMut)]
+pub struct Target(Entity);
+
+pub trait PathFindingThinker {
+    fn find_path<T: Thinking>(self) -> Self;
+}
+
+impl PathFindingThinker for ThinkerBuilder {
+    fn find_path<T: Thinking>(self) -> Self {
+        self.when(
+            FindTargetScorer::<T>::default(),
+            Steps::build()
+                .label("FindClosestTarget")
+                .step(FindClosestTarget::<T>::default()),
+        )
+    }
+}
+
+#[derive(Clone, Component, Debug, ScorerBuilder)]
+pub struct FindTargetScorer<T: Thinking>(Timer, PhantomData<T>);
+
+impl<T: Thinking> Default for FindTargetScorer<T> {
+    fn default() -> Self {
+        Self(Timer::from_seconds(0.5, TimerMode::Repeating), PhantomData)
+    }
+}
+
+#[derive(Clone, Component, Debug, ActionBuilder)]
+pub struct FindClosestTarget<T: Thinking>(PhantomData<T>);
+
+impl<T: Thinking> Default for FindClosestTarget<T> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+pub fn find_path_scorer<T: Thinking + Component>(
+    time: Res<Time>,
+    mut query: Query<(&Actor, &mut Score, &mut FindTargetScorer<T>)>,
+) {
+    for (Actor(_actor), mut score, mut scorer) in &mut query {
+        if scorer.0.tick(time.delta()).just_finished() {
+            score.set(0.7);
+        } else {
+            score.set(0.);
+        }
+    }
+}
+
+pub fn find_closest_target<T: Component + Thinking>(
+    mut cmd: Commands,
+    positions: Query<&TilePosition>,
+    flags_cache: Res<Cache<TilePosition, Flags>>,
+    q_target_positions: Query<(Entity, &TilePosition), With<T>>,
+    mut action_query: Query<(&Actor, &mut ActionState, &FindClosestTarget<T>, &ActionSpan)>,
+) {
+    for (actor, mut action_state, _, span) in &mut action_query {
+        let _guard = span.span().enter();
+
+        match *action_state {
+            ActionState::Requested => {
+                debug!("Finding closest target!");
+                *action_state = ActionState::Executing;
+            }
+            ActionState::Executing => {
+                let actor_position = positions.get(actor.0).expect("actor has no position");
+                let closest_target = get_closest_target(actor_position, &q_target_positions);
+
+                let Some((target, closest_target)) = closest_target else {
+                    debug!("No closest target found, failing.");
+                    *action_state = ActionState::Failure;
+                    continue;
+                };
+
+                let target_pos = get_closest_valid_surrounding_position(
+                    &closest_target,
+                    actor_position,
+                    1,
+                    2,
+                    &flags_cache,
+                );
+
+                let Some(target_pos) = target_pos else {
+                    debug!("Unreachable path, failing.");
+                    *action_state = ActionState::Failure;
+                    continue;
+                };
+
+                if *actor_position == target_pos {
+                    debug!("Target is already at the closest valid position, failing.");
+                    *action_state = ActionState::Failure;
+                    continue;
+                };
+
+                cmd.entity(actor.0).insert((
+                    Target(target),
+                    TiledPathFindingQuery::new(target_pos)
+                        .with_success_range((0., 0.))
+                        .with_timeout(Duration::from_secs(2)),
+                ));
+
+                debug!("Calculating path towards {:?}", target_pos);
+                *action_state = ActionState::Success;
+            }
+            ActionState::Cancelled => {
+                *action_state = ActionState::Failure;
+            }
+            _ => {}
+        }
+    }
+}
+
+fn get_closest_target<T: Component>(
+    actor_position: &TilePosition,
+    q_target_positions: &Query<(Entity, &TilePosition), With<T>>,
+) -> Option<(Entity, TilePosition)> {
+    q_target_positions
+        .iter()
+        .min_by(|(_, &a), (_, &b)| {
+            a.distance(actor_position)
+                .partial_cmp(&b.distance(actor_position))
+                .unwrap()
+        })
+        .map(|(entity, pos)| (entity, *pos))
+}
+
+fn get_closest_valid_surrounding_position(
+    destination_pos: &TilePosition,
+    actor_pos: &TilePosition,
+    cardinal_cost: u32,
+    diagonal_cost: u32,
+    flags_cache: &Res<Cache<TilePosition, Flags>>,
+) -> Option<TilePosition> {
+    let surrounding_positions = weighted_neighbors_2d_generator(
+        destination_pos,
+        &|pos| pos.is_navigable(flags_cache) || pos == actor_pos,
+        cardinal_cost,
+        diagonal_cost,
+    );
+
+    surrounding_positions
+        .iter()
+        .min_by(|(a, a_weight), (b, b_weight)| {
+            (a.distance(actor_pos) * *a_weight as f32)
+                .partial_cmp(&(b.distance(actor_pos) * *b_weight as f32))
+                .unwrap()
+        })
+        .map(|(pos, _)| *pos)
+}

--- a/crates/ryot_brain/src/follow_path.rs
+++ b/crates/ryot_brain/src/follow_path.rs
@@ -1,0 +1,195 @@
+use crate::find_closest::Target;
+use bevy::prelude::*;
+use big_brain::actions::ActionState;
+use big_brain::prelude::*;
+use rand::prelude::SliceRandom;
+use ryot_core::prelude::*;
+use ryot_pathfinder::prelude::*;
+use ryot_tiled::prelude::*;
+use ryot_utils::prelude::*;
+use std::ops::Deref;
+
+pub trait PathFollowingThinker {
+    fn follows_path(self) -> Self;
+    fn follows_path_with_fallback(self, default: impl ActionBuilder + 'static) -> Self;
+}
+
+impl PathFollowingThinker for ThinkerBuilder {
+    fn follows_path(self) -> Self {
+        self.when(
+            FollowPathScore::default(),
+            Steps::build().label("FollowPath").step(FollowPath),
+        )
+    }
+
+    fn follows_path_with_fallback(self, default: impl ActionBuilder + 'static) -> Self {
+        self.when(
+            FollowPathScore::default(),
+            Steps::build()
+                .label("FollowPath")
+                .step(FollowPath)
+                .step(default),
+        )
+    }
+}
+
+#[derive(Clone, Component, Debug, ScorerBuilder)]
+pub struct FollowPathScore(Timer);
+
+impl Default for FollowPathScore {
+    fn default() -> Self {
+        Self(Timer::from_seconds(1., TimerMode::Repeating))
+    }
+}
+
+#[derive(Clone, Component, Debug, ActionBuilder)]
+pub struct FollowPath;
+
+pub fn follow_path_scorer(
+    time: Res<Time>,
+    targets: Query<&Target>,
+    positions: Query<&TilePosition>,
+    mut query: Query<(&Actor, &mut Score, &mut FollowPathScore)>,
+) {
+    for (Actor(actor), mut score, mut scorer) in &mut query {
+        let actor_position = positions.get(*actor).expect("actor has no position");
+
+        let is_far_from_target = targets.get(*actor).map_or(true, |target| {
+            let target_position = positions
+                .get(*target.deref())
+                .expect("target has no position");
+
+            actor_position.distance(target_position) > 1.42
+        });
+
+        if scorer.0.tick(time.delta()).just_finished() && is_far_from_target {
+            scorer.0.reset();
+            score.set(0.7);
+        } else {
+            score.set(0.);
+        }
+    }
+}
+
+pub fn follow_path<T: From<OrdinalDirection>>(
+    positions: Query<&TilePosition>,
+    mut paths: Query<&mut TiledPath>,
+    flags_cache: Res<Cache<TilePosition, Flags>>,
+    mut action_query: Query<(&Actor, &mut ActionState, &FollowPath, &ActionSpan)>,
+) -> Vec<(Entity, T)> {
+    let mut result = Vec::new();
+
+    for (Actor(actor), mut action_state, _, span) in &mut action_query {
+        let _guard = span.span().enter();
+
+        match *action_state {
+            ActionState::Requested => {
+                debug!("Let's follow the path!");
+                *action_state = ActionState::Executing;
+            }
+            ActionState::Executing => {
+                let actor_position = positions.get(*actor).expect("actor has no position");
+                let Ok(mut path) = paths.get_mut(*actor) else {
+                    debug!("Actor has no path.");
+                    *action_state = ActionState::Success;
+                    continue;
+                };
+
+                let Some(next_pos) = path.first().copied() else {
+                    debug!("Actor path is empty.");
+                    *action_state = ActionState::Success;
+                    continue;
+                };
+
+                path.remove(0);
+
+                if next_pos == *actor_position {
+                    if path.is_empty() {
+                        *action_state = ActionState::Failure;
+                    }
+
+                    continue;
+                }
+
+                if !next_pos.is_navigable(&flags_cache) {
+                    debug!("Next position is not valid, failing.");
+                    *action_state = ActionState::Failure;
+                } else {
+                    debug!("Moving to {:?}", next_pos);
+                    result.push((*actor, T::from(actor_position.direction_to(next_pos))));
+                    *action_state = ActionState::Failure;
+                }
+            }
+            ActionState::Cancelled => {
+                *action_state = ActionState::Failure;
+            }
+            _ => {}
+        }
+    }
+
+    result
+}
+
+#[derive(Clone, Component, Debug, ActionBuilder)]
+pub struct MovesRandomly;
+
+pub fn moves_randomly<T: From<OrdinalDirection>>(
+    positions: Query<&TilePosition>,
+    flags_cache: Res<Cache<TilePosition, Flags>>,
+    mut action_query: Query<(&Actor, &mut ActionState, &MovesRandomly, &ActionSpan)>,
+) -> Vec<(Entity, T)> {
+    let mut result = Vec::new();
+
+    for (Actor(actor), mut action_state, _, span) in &mut action_query {
+        let _guard = span.span().enter();
+
+        match *action_state {
+            ActionState::Requested => {
+                debug!("Let's move randomly!");
+                *action_state = ActionState::Executing;
+            }
+            ActionState::Executing => {
+                let actor_position = positions.get(*actor).expect("actor has no position");
+                let random_neighbor =
+                    get_weighted_random_neighbor(actor_position, 1, 2, &flags_cache);
+
+                if let Some(next) = random_neighbor {
+                    debug!("Moving actor randomly to {:?}", next);
+                    result.push((*actor, T::from(actor_position.direction_to(next))));
+                    *action_state = ActionState::Success;
+                } else {
+                    debug!("No valid position found for actor {:?}", actor);
+                    *action_state = ActionState::Failure;
+                }
+            }
+            ActionState::Cancelled => {
+                *action_state = ActionState::Failure;
+            }
+            _ => {}
+        }
+    }
+
+    result
+}
+
+fn get_weighted_random_neighbor(
+    pos: &TilePosition,
+    cardinal_cost: u32,
+    diagonal_cost: u32,
+    flags_cache: &Res<Cache<TilePosition, Flags>>,
+) -> Option<TilePosition> {
+    let mut cardinal = weighted_neighbors_2d_generator(
+        pos,
+        &|pos| pos.is_navigable(flags_cache),
+        cardinal_cost,
+        diagonal_cost,
+    )
+    .into_iter()
+    .filter(|(_, cost)| *cost == cardinal_cost)
+    .collect::<Vec<(TilePosition, u32)>>();
+
+    let mut rng = rand::thread_rng();
+
+    cardinal.shuffle(&mut rng);
+    cardinal.last().map(|(pos, _)| *pos)
+}

--- a/crates/ryot_brain/src/follow_path.rs
+++ b/crates/ryot_brain/src/follow_path.rs
@@ -1,5 +1,5 @@
-use crate::find_closest::Target;
 use bevy::prelude::*;
+use bevy::utils::HashMap;
 use big_brain::actions::ActionState;
 use big_brain::prelude::*;
 use rand::prelude::SliceRandom;
@@ -7,87 +7,56 @@ use ryot_core::prelude::*;
 use ryot_pathfinder::prelude::*;
 use ryot_tiled::prelude::*;
 use ryot_utils::prelude::*;
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
 
 pub trait PathFollowingThinker {
-    fn follows_path(self, duration_sec: f32) -> Self;
-    fn follows_path_with_fallback(
-        self,
-        duration_sec: f32,
-        default: impl ActionBuilder + 'static,
-    ) -> Self;
+    fn follows_path(self) -> Self;
 }
 
 impl PathFollowingThinker for ThinkerBuilder {
-    fn follows_path(self, duration_sec: f32) -> Self {
+    fn follows_path(self) -> Self {
         self.when(
-            FollowPathScore::with_duration_in_seconds(duration_sec),
+            FollowPathScore,
             Steps::build().label("FollowPath").step(FollowPath),
         )
     }
-
-    fn follows_path_with_fallback(
-        self,
-        duration_sec: f32,
-        default: impl ActionBuilder + 'static,
-    ) -> Self {
-        self.when(
-            FollowPathScore::with_duration_in_seconds(duration_sec),
-            Steps::build()
-                .label("FollowPath")
-                .step(FollowPath)
-                .step(default),
-        )
-    }
 }
 
-#[derive(Clone, Component, Debug, ScorerBuilder)]
-pub struct FollowPathScore(pub Timer);
-
-impl Default for FollowPathScore {
-    fn default() -> Self {
-        Self::with_duration_in_seconds(1.)
-    }
-}
-
-impl FollowPathScore {
-    fn with_duration_in_seconds(duration: f32) -> Self {
-        Self(Timer::from_seconds(duration, TimerMode::Repeating))
-    }
-}
+#[derive(Clone, Component, Default, Debug, ScorerBuilder)]
+pub struct FollowPathScore;
 
 #[derive(Clone, Component, Debug, ActionBuilder)]
 pub struct FollowPath;
 
 pub fn follow_path_scorer(
-    time: Res<Time>,
-    targets: Query<&Target>,
-    positions: Query<&TilePosition>,
-    mut query: Query<(&Actor, &mut Score, &mut FollowPathScore)>,
+    paths: Query<&TiledPath>,
+    cooldowns: Query<&Cooldown<Thinker>>,
+    mut query: Query<(&Actor, &mut Score), With<FollowPathScore>>,
 ) {
-    for (Actor(actor), mut score, mut scorer) in &mut query {
-        let actor_position = positions.get(*actor).expect("actor has no position");
+    for (Actor(actor), mut score) in &mut query {
+        let can_walk = paths.get(*actor).map_or(false, |path| !path.is_empty());
 
-        let is_far_from_target = targets.get(*actor).map_or(true, |target_position| {
-            actor_position.distance(target_position) > 0.
-        });
-
-        if scorer.0.tick(time.delta()).just_finished() && is_far_from_target {
-            scorer.0.reset();
-            score.set(0.7);
+        if is_valid_cooldown_for_entity(actor, &cooldowns) && can_walk {
+            score.set(0.6);
         } else {
             score.set(0.);
         }
     }
 }
 
-pub fn follow_path<T: From<OrdinalDirection>>(
+#[derive(Event, Clone, Copy, Debug)]
+pub struct WalkTo(pub Entity, pub TilePosition);
+
+pub fn follow_path(
     mut cmd: Commands,
-    positions: Query<&TilePosition>,
-    mut paths: Query<&mut TiledPath>,
+    mut walk_writer: EventWriter<WalkTo>,
+    mut amend_writer: EventWriter<AmendPathCommand<TilePosition>>,
     flags_cache: Res<Cache<TilePosition, Flags>>,
+    mut q_actor: Query<(&mut TiledPath, &TilePosition)>,
     mut action_query: Query<(&Actor, &mut ActionState, &FollowPath, &ActionSpan)>,
-) -> Vec<(Entity, T)> {
-    let mut result = Vec::new();
+) {
+    let flags_cache_arc = Arc::clone(&flags_cache);
 
     for (Actor(actor), mut action_state, _, span) in &mut action_query {
         let _guard = span.span().enter();
@@ -98,80 +67,91 @@ pub fn follow_path<T: From<OrdinalDirection>>(
                 *action_state = ActionState::Executing;
             }
             ActionState::Executing => {
-                let actor_position = positions.get(*actor).expect("actor has no position");
-                let Ok(mut path) = paths.get_mut(*actor) else {
-                    debug!("Actor has no path.");
-                    cmd.entity(*actor).remove::<Target>();
+                let Ok((mut path, actor_position)) = q_actor.get_mut(*actor) else {
+                    debug!("Invalid actor.");
                     *action_state = ActionState::Success;
                     continue;
                 };
 
-                let Some(next_pos) = path.first().copied() else {
+                if path.is_empty() {
                     debug!("Actor path is empty.");
-                    cmd.entity(*actor).remove::<Target>();
+                    cmd.entity(*actor).remove::<TiledPath>();
                     *action_state = ActionState::Success;
                     continue;
                 };
 
-                path.remove(0);
-
-                if next_pos == *actor_position {
-                    if path.is_empty() {
-                        *action_state = ActionState::Cancelled;
-                    }
-
+                let Some((index, next_pos)) =
+                    path.iter().copied().enumerate().find(|(_, next_pos)| {
+                        *next_pos != *actor_position
+                            && next_pos.can_be_navigated(flags_cache_arc.clone())
+                    })
+                else {
+                    cmd.entity(*actor).remove::<TiledPath>();
+                    *action_state = ActionState::Success;
                     continue;
+                };
+
+                let mut removed = path.remove(0);
+
+                if removed == *actor_position {
+                    removed = path.remove(0);
                 }
 
-                if !next_pos.is_navigable(&flags_cache) {
-                    debug!("Next position is not valid, failing.");
-                    *action_state = ActionState::Cancelled;
+                *action_state = ActionState::Failure;
+
+                if removed != next_pos {
+                    debug!("Amending path towards {:?}", next_pos);
+                    amend_writer.send(AmendPathCommand {
+                        entity: *actor,
+                        path_amend_index: index,
+                        path_finding_query: TiledPathFindingQuery::new(next_pos)
+                            .with_diagonal_cost(3)
+                            .with_success_range((0., 0.))
+                            .with_timeout(Duration::from_millis(10)),
+                    });
                 } else {
                     debug!("Moving to {:?}", next_pos);
-                    result.push((*actor, T::from(actor_position.direction_to(next_pos))));
-                    *action_state = ActionState::Failure;
+                    walk_writer.send(WalkTo(*actor, next_pos));
                 }
             }
             ActionState::Cancelled => {
-                cmd.entity(*actor).remove::<Target>();
                 *action_state = ActionState::Failure;
             }
             _ => {}
         }
     }
-
-    result
 }
 
 #[derive(Clone, Component, Debug, ActionBuilder)]
 pub struct MovesRandomly;
 
-pub fn moves_randomly<T: From<OrdinalDirection>>(
+pub fn moves_randomly(
     positions: Query<&TilePosition>,
+    mut walk_writer: EventWriter<WalkTo>,
     flags_cache: Res<Cache<TilePosition, Flags>>,
     mut action_query: Query<(&Actor, &mut ActionState, &MovesRandomly, &ActionSpan)>,
-) -> Vec<(Entity, T)> {
-    let mut result = Vec::new();
+) {
+    let flags_cache_arc = Arc::clone(&flags_cache);
 
     for (Actor(actor), mut action_state, _, span) in &mut action_query {
         let _guard = span.span().enter();
 
         match *action_state {
             ActionState::Requested => {
-                debug!("Let's move randomly!");
+                trace!("Let's move randomly!");
                 *action_state = ActionState::Executing;
             }
             ActionState::Executing => {
                 let actor_position = positions.get(*actor).expect("actor has no position");
                 let random_neighbor =
-                    get_weighted_random_neighbor(actor_position, 1, 2, &flags_cache);
+                    get_weighted_random_neighbor(actor_position, 1, 2, flags_cache_arc.clone());
 
                 if let Some(next) = random_neighbor {
-                    debug!("Moving actor randomly to {:?}", next);
-                    result.push((*actor, T::from(actor_position.direction_to(next))));
+                    info!("Moving actor randomly to {:?}", next);
+                    walk_writer.send(WalkTo(*actor, next));
                     *action_state = ActionState::Success;
                 } else {
-                    debug!("No valid position found for actor {:?}", actor);
+                    info!("No valid position found for actor {:?}", actor);
                     *action_state = ActionState::Failure;
                 }
             }
@@ -181,19 +161,17 @@ pub fn moves_randomly<T: From<OrdinalDirection>>(
             _ => {}
         }
     }
-
-    result
 }
 
 fn get_weighted_random_neighbor(
     pos: &TilePosition,
     cardinal_cost: u32,
     diagonal_cost: u32,
-    flags_cache: &Res<Cache<TilePosition, Flags>>,
+    flags_cache: Arc<RwLock<HashMap<TilePosition, Flags>>>,
 ) -> Option<TilePosition> {
     let mut cardinal = weighted_neighbors_2d_generator(
         pos,
-        &|pos| pos.is_navigable(flags_cache),
+        &|pos| pos.can_be_navigated(flags_cache.clone()),
         cardinal_cost,
         diagonal_cost,
     )
@@ -205,4 +183,23 @@ fn get_weighted_random_neighbor(
 
     cardinal.shuffle(&mut rng);
     cardinal.last().map(|(pos, _)| *pos)
+}
+
+pub fn walk_to_direction<T: From<OrdinalDirection>>(
+    mut walk_reader: EventReader<WalkTo>,
+    mut positions: Query<&mut TilePosition>,
+) -> Vec<(Entity, T)> {
+    walk_reader
+        .read()
+        .filter_map(|WalkTo(entity, next_pos)| {
+            Some((
+                *entity,
+                positions
+                    .get_mut(*entity)
+                    .ok()?
+                    .direction_to(*next_pos)
+                    .into(),
+            ))
+        })
+        .collect::<Vec<_>>()
 }

--- a/crates/ryot_brain/src/lib.rs
+++ b/crates/ryot_brain/src/lib.rs
@@ -1,16 +1,20 @@
 #![feature(trait_alias)]
+#![feature(let_chains)]
+
 mod find_closest;
 mod follow_path;
+mod pickers;
 
 pub mod prelude {
     pub use crate::{
         find_closest::{
-            find_closest_target, find_path_scorer, FindClosestTarget, FindTargetScorer,
-            PathFindingThinker, Target,
+            find_closest_target, find_path_scorer, FindClosestTarget, FindTargetScore,
+            PathFindingThinker, ThinkerBundle,
         },
         follow_path::{
-            follow_path, follow_path_scorer, moves_randomly, FollowPath, FollowPathScore,
-            MovesRandomly, PathFollowingThinker,
+            follow_path, follow_path_scorer, moves_randomly, walk_to_direction, FollowPath,
+            FollowPathScore, MovesRandomly, PathFollowingThinker, WalkTo,
         },
+        pickers::HighestWithThreshold,
     };
 }

--- a/crates/ryot_brain/src/lib.rs
+++ b/crates/ryot_brain/src/lib.rs
@@ -1,0 +1,16 @@
+#![feature(trait_alias)]
+mod find_closest;
+mod follow_path;
+
+pub mod prelude {
+    pub use crate::{
+        find_closest::{
+            find_closest_target, find_path_scorer, FindClosestTarget, FindTargetScorer,
+            PathFindingThinker, Target,
+        },
+        follow_path::{
+            follow_path, follow_path_scorer, moves_randomly, FollowPath, FollowPathScore,
+            MovesRandomly, PathFollowingThinker,
+        },
+    };
+}

--- a/crates/ryot_brain/src/pickers.rs
+++ b/crates/ryot_brain/src/pickers.rs
@@ -1,0 +1,28 @@
+use bevy::prelude::*;
+use big_brain::choices::Choice;
+use big_brain::prelude::*;
+
+#[derive(Debug, Clone, Default)]
+pub struct HighestWithThreshold {
+    pub threshold: f32,
+}
+
+impl HighestWithThreshold {
+    pub const ZERO_OR_MORE: Self = Self::new(0.0);
+
+    pub const fn new(threshold: f32) -> Self {
+        Self { threshold }
+    }
+}
+
+impl Picker for HighestWithThreshold {
+    fn pick<'a>(&self, choices: &'a [Choice], scores: &Query<&Score>) -> Option<&'a Choice> {
+        Highest.pick(choices, scores).and_then(|choice| {
+            if choice.calculate(scores) >= self.threshold {
+                Some(choice)
+            } else {
+                None
+            }
+        })
+    }
+}

--- a/crates/ryot_internal/Cargo.toml
+++ b/crates/ryot_internal/Cargo.toml
@@ -36,6 +36,11 @@ compression = ["ryot_utils/compression"]
 egui = ["ryot_tiled/egui"]
 lmdb = ["ryot_tiled/lmdb"]
 
+brain = [
+    "bevy",
+    "dep:ryot_brain",
+]
+
 ray_casting = [
     "bevy",
     "ryot_tiled/ray_casting",
@@ -54,6 +59,7 @@ ryot_tibia = [
 
 [dependencies]
 ryot_assets = { workspace = true, optional = true }
+ryot_brain = { workspace = true, optional = true }
 ryot_core.workspace = true
 ryot_pathfinder = { workspace = true, optional = true }
 ryot_sprites.workspace = true

--- a/crates/ryot_internal/src/lib.rs
+++ b/crates/ryot_internal/src/lib.rs
@@ -29,6 +29,11 @@ pub mod tiled {
     pub use ryot_tiled::*;
 }
 
+#[cfg(feature = "brain")]
+pub mod brain {
+    pub use ryot_brain::*;
+}
+
 #[cfg(feature = "pathfinding")]
 pub mod pathfinder {
     pub use ryot_pathfinder::*;

--- a/crates/ryot_internal/src/prelude.rs
+++ b/crates/ryot_internal/src/prelude.rs
@@ -6,6 +6,9 @@ pub use ryot_utils::prelude::*;
 #[cfg(feature = "bevy")]
 pub use ryot_assets::prelude::*;
 
+#[cfg(feature = "brain")]
+pub use ryot_brain::prelude::*;
+
 #[cfg(feature = "pathfinding")]
 pub use ryot_pathfinder::prelude::*;
 

--- a/crates/ryot_pathfinder/Cargo.toml
+++ b/crates/ryot_pathfinder/Cargo.toml
@@ -26,6 +26,7 @@ bevy_app.workspace = true
 bevy_ecs.workspace = true
 bevy_math.workspace = true
 bevy_tasks = { workspace = true, features = ["multi-threaded"] }
+bevy_utils.workspace = true
 
 ryot_core.workspace = true
 ryot_utils.workspace = true

--- a/crates/ryot_pathfinder/src/commands.rs
+++ b/crates/ryot_pathfinder/src/commands.rs
@@ -1,0 +1,10 @@
+use crate::components::PathFindingQuery;
+use crate::pathable::Pathable;
+use bevy_ecs::prelude::*;
+
+#[derive(Event, Clone, Copy)]
+pub struct AmendPathCommand<P: Pathable> {
+    pub entity: Entity,
+    pub path_amend_index: usize,
+    pub path_finding_query: PathFindingQuery<P>,
+}

--- a/crates/ryot_pathfinder/src/components.rs
+++ b/crates/ryot_pathfinder/src/components.rs
@@ -71,15 +71,17 @@ pub struct PathFindingQuery<P: Pathable> {
 ///             continue;
 ///         }
 ///
-///         let Some(next_pos) = path.first().copied() else {
-///             continue;
-///         };
-///
-///         path.remove(0);
+///         let next_pos = path.remove(0);
 ///     }
 /// }
 #[derive(Component, Clone, Default, Debug, Deref, DerefMut)]
-pub struct Path<P: Pathable>(pub(crate) Vec<P>);
+pub struct Path<P: Pathable>(Vec<P>);
+
+impl<P: Pathable> Path<P> {
+    pub fn new(path: Vec<P>) -> Self {
+        Path(path)
+    }
+}
 
 /// Manages the asynchronous execution of pathfinding tasks, holding a future
 /// that resolves to the computed path and associated costs.

--- a/crates/ryot_pathfinder/src/lib.rs
+++ b/crates/ryot_pathfinder/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
+pub mod commands;
 pub mod components;
 pub mod pathable;
 pub mod systems;
@@ -11,6 +12,7 @@ pub mod stubs;
 
 pub mod prelude {
     pub use crate::{
+        commands::AmendPathCommand,
         components::{Path, PathFindingQuery},
         pathable::{Pathable, PathableApp},
         systems::PathFindingSystems,

--- a/crates/ryot_ray_casting/src/app.rs
+++ b/crates/ryot_ray_casting/src/app.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::systems::{remove_stale_requests, remove_stale_results};
-use bevy_app::{App, PostUpdate, Update};
+use bevy_app::{App, PostUpdate, PreUpdate, Update};
 use bevy_ecs::prelude::*;
 use ryot_core::prelude::Navigable;
 use ryot_utils::prelude::*;
@@ -28,9 +28,12 @@ impl RayCastingApp for App {
         self.init_resource_once::<Cache<P, N>>()
             .init_resource::<SimpleCache<RadialArea<P>, Vec<Vec<P>>>>()
             .add_systems(
+                PreUpdate,
+                update_intersection_cache::<Marker, P>.in_set(CacheSystems::UpdateCache),
+            )
+            .add_systems(
                 Update,
                 (
-                    update_intersection_cache::<Marker, P>.in_set(CacheSystems::UpdateCache),
                     process_ray_casting::<Marker, P, N>
                         .in_set(RayCastingSystems::Process)
                         .after(CacheSystems::UpdateCache),

--- a/crates/ryot_sprites/src/material/shaders/sprite.wgsl
+++ b/crates/ryot_sprites/src/material/shaders/sprite.wgsl
@@ -72,7 +72,7 @@ fn fragment(
 
     var outlined = mix(base, outline_color, outline_alpha - base.a);
     var tinted = mix(outlined, vec4<f32>(outlined.rgb * material.tint.rgb, outlined.a), material.tint.a);
-    tinted.a *= material.alpha;
+    tinted.a *= clamp(material.alpha, 0.0, 1.0);
     return tinted;
 }
 

--- a/crates/ryot_tiled/src/flags.rs
+++ b/crates/ryot_tiled/src/flags.rs
@@ -1,13 +1,12 @@
 use crate::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_render::prelude::*;
+use bevy_utils::HashMap;
 use ryot_core::prelude::*;
 use ryot_utils::prelude::*;
 
-pub fn update_tile_flag_cache<N: Navigable + Copy + Default + Component>(
-    visual_elements: Res<VisualElements>,
+pub fn collect_updatable_positions(
     map_tiles: Res<MapTiles<Entity>>,
-    cache: ResMut<Cache<TilePosition, N>>,
     q_updated_entities: Query<
         (Option<&PreviousPosition>, &TilePosition),
         Or<(
@@ -16,60 +15,82 @@ pub fn update_tile_flag_cache<N: Navigable + Copy + Default + Component>(
             Changed<TilePosition>,
         )>,
     >,
+) -> HashMap<TilePosition, (Vec<Entity>, bool)> {
+    let mut pos_map: HashMap<TilePosition, (Vec<Entity>, bool)> = HashMap::new();
+
+    for (previous_pos, new_pos) in q_updated_entities.iter() {
+        match previous_pos {
+            Some(PreviousPosition(previous_pos)) => vec![*new_pos, *previous_pos],
+            None => vec![*new_pos],
+        }
+        .iter()
+        .enumerate()
+        .for_each(|(i, pos)| {
+            if pos_map.contains_key(pos) {
+                return;
+            }
+
+            let Some(tile) = map_tiles.get(pos) else {
+                return;
+            };
+
+            pos_map.insert(
+                *pos,
+                (tile.into_iter().map(|(_, entity)| entity).collect(), i == 0),
+            );
+        });
+    }
+
+    pos_map
+}
+
+pub fn build_new_flags_for_map<N: Navigable + Copy + Default + Component>(
+    In(entities_per_pos): In<HashMap<TilePosition, (Vec<Entity>, bool)>>,
+    visual_elements: Res<VisualElements>,
     q_object_and_visibility: Query<(&ContentId, Option<&Visibility>, Option<&N>)>,
+) -> HashMap<TilePosition, N> {
+    entities_per_pos
+        .into_iter()
+        .map(|(pos, (entities, append_entity_flags))| {
+            (
+                pos,
+                entities.iter().fold(N::default(), |mut flags, entity| {
+                    let Ok((object_id, visibility, entity_flags)) =
+                        q_object_and_visibility.get(*entity)
+                    else {
+                        return flags;
+                    };
+
+                    if visibility == Some(&Visibility::Hidden) {
+                        return flags;
+                    }
+
+                    if append_entity_flags {
+                        flags =
+                            entity_flags.map_or(flags, |e_flags| append_navigable(flags, e_flags));
+                    }
+
+                    object_id
+                        .as_group_and_id()
+                        .and_then(|(group, id)| visual_elements.get_for_group_and_id(group, id))
+                        .map(|visual_element| visual_element.flags)
+                        .filter(|&flags| !flags.is_default())
+                        .map_or_else(|| flags, |a_flags| append_navigable(flags, &a_flags))
+                }),
+            )
+        })
+        .collect::<HashMap<TilePosition, N>>()
+}
+
+pub fn update_tile_flag_cache<N: Navigable>(
+    In(flags_per_pos): In<HashMap<TilePosition, N>>,
+    cache: ResMut<Cache<TilePosition, N>>,
 ) {
     let Ok(mut write_guard) = cache.write() else {
         return;
     };
 
-    for (previous_pos, new_pos) in q_updated_entities.iter() {
-        let previous_pos = match previous_pos {
-            Some(previous_pos) => *previous_pos,
-            None => PreviousPosition(*new_pos),
-        };
-
-        let positions = if previous_pos.0 == *new_pos {
-            vec![*new_pos]
-        } else {
-            vec![previous_pos.0, *new_pos]
-        };
-
-        for pos in &positions {
-            let Some(tile) = map_tiles.get(pos) else {
-                continue;
-            };
-
-            write_guard.insert(
-                *pos,
-                tile.into_iter()
-                    .fold(N::default(), |mut flags, (_, entity)| {
-                        let Ok((object_id, visibility, entity_flags)) =
-                            q_object_and_visibility.get(entity)
-                        else {
-                            return flags;
-                        };
-
-                        if visibility == Some(&Visibility::Hidden) {
-                            return flags;
-                        }
-
-                        if pos == new_pos {
-                            flags = entity_flags.map_or_else(
-                                || flags,
-                                |entity_flags| append_navigable(flags, entity_flags),
-                            );
-                        }
-
-                        flags = object_id
-                            .as_group_and_id()
-                            .and_then(|(group, id)| visual_elements.get_for_group_and_id(group, id))
-                            .map(|visual_element| visual_element.flags)
-                            .filter(|&flags| !flags.is_default())
-                            .map_or_else(|| flags, |a_flags| append_navigable(flags, &a_flags));
-
-                        flags
-                    }),
-            );
-        }
-    }
+    flags_per_pos.into_iter().for_each(|(pos, flags)| {
+        write_guard.insert(pos, flags);
+    });
 }

--- a/crates/ryot_tiled/src/lib.rs
+++ b/crates/ryot_tiled/src/lib.rs
@@ -58,7 +58,7 @@ pub mod prelude {
                 TileComponent,
             },
         },
-        flags::update_tile_flag_cache,
+        flags::{build_new_flags_for_map, collect_updatable_positions, update_tile_flag_cache},
         map::elevation::{apply_elevation, elevate_position, initialize_elevation},
         map::grid::{spawn_grid, GridView},
         map::position::{

--- a/crates/ryot_tiled/src/map/position/interactions.rs
+++ b/crates/ryot_tiled/src/map/position/interactions.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use glam::IVec3;
 use ryot_core::prelude::Point;
 use std::collections::HashSet;
 
@@ -32,5 +33,21 @@ impl TilePosition {
         }
 
         true
+    }
+
+    pub fn get_surroundings(&self) -> Vec<TilePosition> {
+        let mut surroundings = Vec::with_capacity(8);
+
+        for x in -1..=1 {
+            for y in -1..=1 {
+                if x == 0 && y == 0 {
+                    continue;
+                }
+
+                surroundings.push(TilePosition(self.0 + IVec3::new(x, y, 0)));
+            }
+        }
+
+        surroundings
     }
 }

--- a/crates/ryot_tiled/src/map/position/previous.rs
+++ b/crates/ryot_tiled/src/map/position/previous.rs
@@ -12,6 +12,12 @@ use bevy_reflect::prelude::*;
 #[cfg_attr(feature = "bevy", derive(Component, Reflect, Deref, DerefMut))]
 pub struct PreviousPosition(pub TilePosition);
 
+impl From<PreviousPosition> for TilePosition {
+    fn from(pos: PreviousPosition) -> Self {
+        pos.0
+    }
+}
+
 /// System to track changes in the position of entities. Needs to be run after the position
 /// component has been changed, so it can track the previous position.
 /// Better to run it during the [`Last`](Last) or [`PostUpdate`](PostUpdate) stages.

--- a/crates/ryot_tiled/src/map/position/systems.rs
+++ b/crates/ryot_tiled/src/map/position/systems.rs
@@ -122,19 +122,3 @@ pub fn finish_position_animation(
             }
         });
 }
-
-#[cfg(feature = "pathfinding")]
-use ryot_pathfinder::pathable::Pathable;
-#[cfg(feature = "pathfinding")]
-impl TilePosition {
-    pub fn is_navigable(
-        &self,
-        flags_cache: &Res<ryot_utils::cache::Cache<TilePosition, ryot_core::prelude::Flags>>,
-    ) -> bool {
-        if let Ok(read_guard) = flags_cache.read() {
-            self.can_be_navigated(read_guard.get(self))
-        } else {
-            false
-        }
-    }
-}

--- a/crates/ryot_tiled/src/map/position/systems.rs
+++ b/crates/ryot_tiled/src/map/position/systems.rs
@@ -122,3 +122,19 @@ pub fn finish_position_animation(
             }
         });
 }
+
+#[cfg(feature = "pathfinding")]
+use ryot_pathfinder::pathable::Pathable;
+#[cfg(feature = "pathfinding")]
+impl TilePosition {
+    pub fn is_navigable(
+        &self,
+        flags_cache: &Res<ryot_utils::cache::Cache<TilePosition, ryot_core::prelude::Flags>>,
+    ) -> bool {
+        if let Ok(read_guard) = flags_cache.read() {
+            self.can_be_navigated(read_guard.get(self))
+        } else {
+            false
+        }
+    }
+}

--- a/crates/ryot_utils/src/cooldown.rs
+++ b/crates/ryot_utils/src/cooldown.rs
@@ -1,0 +1,69 @@
+use bevy_app::{App, First};
+use bevy_ecs::prelude::*;
+use bevy_time::*;
+use bevy_utils::tracing::warn;
+use std::any::type_name;
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+
+#[derive(Component, Clone, Debug)]
+pub struct Cooldown<M>(Timer, PhantomData<M>);
+
+impl<M> Cooldown<M> {
+    pub fn from_seconds(seconds: f32) -> Self {
+        Self(
+            Timer::from_seconds(seconds, TimerMode::Repeating),
+            PhantomData,
+        )
+    }
+}
+
+impl<M> Default for Cooldown<M> {
+    fn default() -> Self {
+        Self::from_seconds(1.)
+    }
+}
+
+impl<M> Deref for Cooldown<M> {
+    type Target = Timer;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<M> DerefMut for Cooldown<M> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+pub trait CooldownApp {
+    fn add_cooldown<M: crate::ThreadSafe>(&mut self) -> &mut Self;
+}
+
+impl CooldownApp for App {
+    fn add_cooldown<M: crate::ThreadSafe>(&mut self) -> &mut Self {
+        self.add_systems(First, cooldown_system::<M>);
+        self
+    }
+}
+
+pub fn cooldown_system<M: crate::ThreadSafe>(time: Res<Time>, mut query: Query<&mut Cooldown<M>>) {
+    query.par_iter_mut().for_each(|mut cooldown| {
+        cooldown.tick(time.delta());
+    });
+}
+
+pub fn is_valid_cooldown_for_entity<M: crate::ThreadSafe>(
+    entity: &Entity,
+    query: &Query<&Cooldown<M>>,
+) -> bool {
+    query.get(*entity).map_or_else(
+        |_| {
+            warn!("Cooldown<M> not configured for M = {}", type_name::<M>());
+            true
+        },
+        |cooldown| cooldown.just_finished(),
+    )
+}

--- a/crates/ryot_utils/src/lib.rs
+++ b/crates/ryot_utils/src/lib.rs
@@ -22,7 +22,7 @@ pub mod app;
 pub mod window;
 
 pub mod prelude {
-    pub use crate::{async_task::execute, is_true};
+    pub use crate::{async_task::execute, is_true, ThreadSafe};
 
     #[cfg(feature = "bevy")]
     pub use crate::{
@@ -32,7 +32,6 @@ pub mod prelude {
         conditions::{on_hold_every, run_every, run_every_millis, run_every_secs, TimeArg},
         on_hold_every,
         window::entitled_window,
-        ThreadSafe,
     };
 
     #[cfg(feature = "compression")]

--- a/crates/ryot_utils/src/lib.rs
+++ b/crates/ryot_utils/src/lib.rs
@@ -4,6 +4,9 @@
 //! Provides general utilities and helpers that are fundamental across the Ryot framework.
 //! This crate includes functions and structs that assist in various aspects of game development,
 //! ensuring that core utilities are reusable and accessible.
+
+#[cfg(feature = "bevy")]
+pub mod app;
 #[cfg(feature = "bevy")]
 pub mod async_events;
 pub mod async_task;
@@ -11,13 +14,10 @@ pub mod async_task;
 pub mod cache;
 #[cfg(feature = "compression")]
 pub mod compression;
-
 #[cfg(feature = "bevy")]
 pub mod conditions;
-
 #[cfg(feature = "bevy")]
-pub mod app;
-
+pub mod cooldown;
 #[cfg(feature = "bevy")]
 pub mod window;
 
@@ -30,6 +30,7 @@ pub mod prelude {
         async_events::{AsyncEventApp, EventSender},
         cache::{Cache, CacheSystems, SimpleCache},
         conditions::{on_hold_every, run_every, run_every_millis, run_every_secs, TimeArg},
+        cooldown::{is_valid_cooldown_for_entity, Cooldown, CooldownApp},
         on_hold_every,
         window::entitled_window,
     };
@@ -39,6 +40,7 @@ pub mod prelude {
 }
 
 pub trait ThreadSafe = Send + Sync + 'static;
+
 pub fn is_true(value: Option<bool>) -> bool {
     value == Some(true)
 }


### PR DESCRIPTION
## Overview
This PR introduces `ryot_brain`, a new crate designed to enhance NPC behavior with advanced decision-making capabilities in Bevy-based games. Leveraging the [big_brain](https://github.com/zkat/big-brain/tree/main) crate, `ryot_brain` adds sophisticated AI behaviors through two primary modules: `find_closest` and `follow_path`. These modules integrate closely with `ryot_pathfinder` and other `ryot` family crates to provide context-aware pathfinding and target tracking functionalities.

## Features
- **Find Closest Target**: NPCs can identify and lock onto the nearest target using a combination of scorers and thinkers.
- **Follow Path**: Once a path is determined, NPCs can follow it intelligently, recalculating as needed based on dynamic game conditions like target movement or terrain changes.
- **Modular Thinkers**: Extensible thinkers allow for easy integration and customization of NPC behaviors, making them adaptable to a wide range of scenarios.

## Goals
The goal of `ryot_brain` is to provide game developers with tools to create more dynamic and intelligent NPCs, enhancing player engagement and game complexity without the need for intricate boilerplate code.

## Integration
`ryot_brain` is designed to seamlessly integrate with existing Bevy projects and is particularly tailored to work with `ryot_pathfinder` for enhanced movement and navigation capabilities.
